### PR TITLE
Fix launcher theme bug and improve error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Noch mehr Befehle zeigt `ANLEITUNG_WEITERE_TIPPS.md`.
 - **Überschriften** – jede Sektion besitzt nun einen klaren Titel, damit man sich leichter zurechtfindet.
 - **Ordner-Prüfung** – vor dem Start wird geprüft, ob der Ausgabeordner vorhanden und beschreibbar ist.
 - **Launcher-Reparatur** – falls die Umgebung fehlt, legt der Launcher sie an und nutzt notfalls das aktuelle Python.
+- **Fehlermeldungen** – auftretende Fehler werden nun abgefangen und verständlich gemeldet. Details stehen im Logfile (Protokolldatei).
 - **Farb-Themes** – über das Menü "Theme" stehen fünf sehr unterschiedliche Farbkombinationen bereit.
 - **Schriftgröße** – im Menü "Ansicht" lässt sich die Schrift stufenweise anpassen.
 

--- a/ereignislog.txt
+++ b/ereignislog.txt
@@ -36,3 +36,4 @@
 [2025-07-24] Virtuelle Umgebung genutzt und Pakete installiert
 [2025-07-24] Zwei neue Laientipps zu crop und Geschwindigkeit
 [2025-07-24] setup-sh.txt erstellt und Dokumentation gelesen (Aufgabe erledigt)
+[2025-07-24] Syntaxfehler im Theme behoben, Launcher zeigt nun verständliche Fehlermeldungen

--- a/todo.txt
+++ b/todo.txt
@@ -39,7 +39,7 @@
 - [x] Abschnitt "Schrift und Farben im Tool" in `ANLEITUNG_LAIENPLUS.md` lesen
 - [x] Dokumentation lesen: `README.md` und `ANLEITUNG_EINSTEIGER.md`
 - [x] Zusätzliche Tipps lesen: `ANLEITUNG_TIPPS.md`
-- [ ] Tool über den Launcher starten: `python3 videobatch_launcher.py`
+ - [x] Tool über den Launcher starten: `python3 videobatch_launcher.py`
 - [ ] Dokumentation lesen: `README.md`, `ANLEITUNG_GESAMT.md`, `ANLEITUNG_LAIENPLUS.md`
 - [ ] Modus "Slideshow" ausprobieren
 - [ ] Modus "Video + Audio" ausprobieren
@@ -49,7 +49,7 @@
 - [ ] "Pfad kopieren" im Kontextmenü testen
 - [ ] Tooltip über Tabelle testen (zeigt Hinweis bei Mauszeiger)
 - [ ] Knopf "Ausgabeordner öffnen" testen
-- [ ] Ereignislog aktualisieren: `ereignislog.txt`
+ - [x] Ereignislog aktualisieren: `ereignislog.txt`
 - [ ] Abschnitt "Noch mehr Beispiele" in der Anleitung lesen
 - [ ] Abschnitt "Weiterführende Befehle" lesen
 - [ ] Neues Hilfefenster prüfen

--- a/videobatch_gui.py
+++ b/videobatch_gui.py
@@ -40,7 +40,6 @@ THEMES = {
     "Gruen": "QWidget{background-color:#28342b;color:#d4ffd4;} QPushButton{background-color:#385b3c;color:white;}",
     "Retro": "QWidget{background-color:#f5deb3;color:#00008b;} QPushButton{background-color:#cd853f;color:black;}",
     "Kontrast": "QWidget{background-color:#000;color:#ffff00;} QPushButton{background-color:#000;color:#ffff00;border:1px solid #ffff00;}"
-    "Retro": "QWidget{background-color:#f5deb3;color:#00008b;} QPushButton{background-color:#cd853f;color:black;}"
 }
 
 # ---------- Helpers ----------

--- a/videobatch_launcher.py
+++ b/videobatch_launcher.py
@@ -72,7 +72,11 @@ def bootstrap_console():
 def main():
     bootstrap_console()
 
-    from PySide6 import QtWidgets
+    try:
+        from PySide6 import QtWidgets
+    except Exception as e:
+        print("Qt konnte nicht geladen werden:", e)
+        sys.exit(1)
     import subprocess as sp
 
     class Wizard(QtWidgets.QDialog):
@@ -164,10 +168,21 @@ def main():
     if wiz.exec() != QtWidgets.QDialog.Accepted:
         sys.exit(0)
 
-    import videobatch_gui as gui
-    w = gui.MainWindow()
-    w.show()
-    sys.exit(app.exec())
+    try:
+        import videobatch_gui as gui
+    except Exception as e:
+        print("Fehler beim Laden der Oberfl\u00e4che:", e)
+        sys.exit(1)
+
+    try:
+        w = gui.MainWindow()
+        w.show()
+        sys.exit(app.exec())
+    except Exception as e:
+        print("Fehler beim Start des Tools:", e)
+        if hasattr(gui, "LOG_FILE"):
+            print("Details stehen in", gui.LOG_FILE)
+        sys.exit(1)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- fix duplicate theme entry causing syntax error
- show helpful error messages in launcher when Qt or GUI fails to load
- mention new error handling in README
- check off completed tasks and record the fix in the log

## Testing
- `pip install -r requirements.txt`
- `python3 videobatch_extra.py --selftest`
- `QT_QPA_PLATFORM=offscreen python3 videobatch_launcher.py`

------
https://chatgpt.com/codex/tasks/task_e_6882518a880c8325889b3c9bd0fbafb5