### PR TITLE
Add selftest to launcher and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Die benoetigten Python-Pakete stehen in `requirements.txt`.
    ```bash
    python3 videobatch_launcher.py
    ```
-   Der Launcher legt bei Bedarf automatisch ein virtuelles Umfeld ("virtual environment") an und installiert die Pakete.
+   Der Launcher legt bei Bedarf automatisch ein virtuelles Umfeld ("virtual environment") an,
+   installiert die Pakete und führt einen kurzen Selbsttest aus. Danach startet die grafische Oberfläche.
 
 Eine ausfuehrliche Anleitung mit allen Tipps steht in `ANLEITUNG_GESAMT.md`.
 Weitere einfache Beispiele bietet `ANLEITUNG_LAIENPLUS.md`.

--- a/todo.txt
+++ b/todo.txt
@@ -1,6 +1,10 @@
 # Aufgabenliste
 
 - [x] Projekt testen: `python3 videobatch_extra.py --selftest`
+- [ ] Launcher nutzen (erstellt Umgebung, installiert Pakete, führt Selbsttest aus):
+      ```bash
+      python3 videobatch_launcher.py
+      ```
 - [ ] Virtuelle Umgebung (isolierte Python-Umgebung) nutzen:
       ```bash
       python3 -m venv .venv
@@ -10,7 +14,6 @@
       ```bash
       pip install -r requirements.txt
       ```
-- [ ] Tool ueber den Launcher starten: `python3 videobatch_launcher.py`
 - [ ] Dokumentation lesen: `README.md`, `ANLEITUNG_GESAMT.md` und `ANLEITUNG_LAIENPLUS.md`
 - [ ] Modus "Slideshow" ausprobieren
 - [ ] Modus "Video + Audio" ausprobieren
@@ -37,3 +40,4 @@
 - [ ] Ereignislog aktualisieren: `ereignislog.txt`
 - [x] Fenstergröße an Bildschirm anpassen (Resize-Bug prüfen)
 - [ ] Verhalten beim Wiederherstellen der Fenstergröße testen
+- [ ] Erweiterte Tests ausführen (benötigt Internet, installiert Prüftools): `python3 0000-testall`

--- a/videobatch_launcher.py
+++ b/videobatch_launcher.py
@@ -36,6 +36,13 @@ def pip_install(py: str, pkgs: list[str]) -> None:
     subprocess.check_call([py, "-m", "pip", "install", "--upgrade", "pip"], stdout=subprocess.DEVNULL)
     subprocess.check_call([py, "-m", "pip", "install", "--upgrade"] + pkgs)
 
+def run_selftest(py: str) -> None:
+    """Startet den kurzen Selbsttest der CLI und zeigt das Ergebnis."""
+    try:
+        subprocess.check_call([py, str(Path(__file__).with_name("videobatch_extra.py")), "--selftest"])
+    except subprocess.CalledProcessError:
+        print("Warnung: Selbsttest meldete einen Fehler. Das Tool wird trotzdem gestartet.")
+
 def reboot_into_venv():
     py  = str(venv_python())
     env = os.environ.copy()
@@ -56,6 +63,9 @@ def bootstrap_console():
 
 def main():
     bootstrap_console()
+
+    # Kurzer Selbsttest der Kommandozeilen-Version
+    run_selftest(str(venv_python()))
 
     from PySide6 import QtWidgets
     import subprocess as sp


### PR DESCRIPTION
## Summary
- run CLI selftest automatically when starting the launcher
- mention new behaviour in the README
- extend the todo list with steps for running the launcher and advanced tests

## Testing
- `python3 videobatch_extra.py --selftest`
- `python3 videobatch_launcher.py` *(fails: libGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68826a66eadc8325890a541faec36c44