### PR TITLE
Fix QShortcut import and extend tips

### DIFF
--- a/ANLEITUNG_LAIENPLUS.md
+++ b/ANLEITUNG_LAIENPLUS.md
@@ -194,3 +194,13 @@ Ein kleines Logo oder ein Schriftzug kann dein Video schützen. So fügst du ihn
 ffmpeg -i video.mp4 -i wasserzeichen.png -filter_complex "overlay=W-w-10:H-h-10" video_mit_wz.mp4
 ```
 *`overlay`* (Überlagerung) setzt das Wasserzeichen zehn Pixel vom unteren und rechten Rand.
+
+## 29. Log-Datei prüfen bei Fehlern
+
+Falls das Programm nicht startet oder eine rote Meldung erscheint, lohnt sich ein Blick in die Protokolldatei ("Log"). Damit öffnest du die neueste Datei:
+
+```bash
+nano ~/.videobatchtool/logs/$(ls -t ~/.videobatchtool/logs | head -n 1)
+```
+
+`nano` ist ein einfacher Texteditor. Die Log-Datei verrät oft die Ursache des Problems.

--- a/ereignislog.txt
+++ b/ereignislog.txt
@@ -75,3 +75,4 @@
 [2025-07-27] Laientipps Teil 19 ergaenzt (Aufgabe 'Weiterfuehrende Laientipps Teil 19 ergaenzen' erledigt)
 [2025-07-27] pool_box Fehler behoben und Laientipps Teil 20 ergaenzt (Aufgabe 'Weiterfuehrende Laientipps Teil 20 ergaenzen' erledigt)
 [2025-07-27] Wasserzeichen-Tipp ergaenzt (Aufgabe 'Weiterfuehrende Laientipps Teil 28 ergaenzen' erledigt)
+[2025-07-27] QShortcut-Bug behoben und Laientipp Teil 29 ergaenzt (Aufgaben erledigt)

--- a/todo.txt
+++ b/todo.txt
@@ -92,3 +92,6 @@ pip install -r requirements.txt
 - [x] Weiterfuehrende Laientipps Teil 26 ergaenzen
 - [x] Weiterfuehrende Laientipps Teil 27 ergaenzen
 - [x] Weiterfuehrende Laientipps Teil 28 ergaenzen
+# Neue Aufgaben
+- [x] QShortcut-Fehler korrigieren
+- [x] Weiterfuehrende Laientipps Teil 29 ergaenzen

--- a/videobatch_gui.py
+++ b/videobatch_gui.py
@@ -745,7 +745,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self._apply_theme(self.settings.value("ui/theme", "Modern"))
         self.restoreGeometry(self.settings.value("ui/geometry", b"", bytes))
         self.restoreState(self.settings.value("ui/window_state", b"", bytes))
-        QtWidgets.QShortcut(QtGui.QKeySequence("F1"), self).activated.connect(
+        QtGui.QShortcut(QtGui.QKeySequence("F1"), self).activated.connect(
             self._show_help_window
         )
 


### PR DESCRIPTION
## Summary
- fix PySide shortcut import
- document how to open error logs
- mark tasks done in todo list
- log the work in `ereignislog.txt`

## Testing
- `python3 videobatch_extra.py --selftest`
- `flake8 videobatch_extra.py videobatch_gui.py videobatch_launcher.py` *(fails: command not found at first, installed, then shows many style errors)*

------
https://chatgpt.com/codex/tasks/task_e_68858ee4c23083258f651d5762b56b4b