### PR TITLE
feat(gui): make sections scalable with Ctrl+Mouse-Wheel

### DIFF
--- a/tests/test_gui_validation.py
+++ b/tests/test_gui_validation.py
@@ -446,6 +446,52 @@ def test_density_profile_changes_workflow_min_size(
     assert large_height >= compact_height
 
 
+def test_ctrl_wheel_scales_font_for_main_window(
+    request, gui_runtime_available, gui_runtime_error
+):
+    if not gui_runtime_available:
+        assert gui_runtime_error is not None
+        return
+
+    qtbot = request.getfixturevalue("qtbot")
+    videobatch_gui = _import_gui_module()
+    win = videobatch_gui.MainWindow()
+    qtbot.addWidget(win)
+    win.show()
+    qtbot.waitExposed(win)
+
+    start_size = win._font_size
+    center = win.rect().center()
+
+    wheel_up = videobatch_gui.QtGui.QWheelEvent(
+        videobatch_gui.QtCore.QPointF(center),
+        videobatch_gui.QtCore.QPointF(center),
+        videobatch_gui.QtCore.QPoint(0, 0),
+        videobatch_gui.QtCore.QPoint(0, 120),
+        videobatch_gui.QtCore.Qt.MouseButton.NoButton,
+        videobatch_gui.QtCore.Qt.KeyboardModifier.ControlModifier,
+        videobatch_gui.QtCore.Qt.ScrollPhase.ScrollUpdate,
+        False,
+    )
+    videobatch_gui.QtWidgets.QApplication.sendEvent(win, wheel_up)
+
+    assert win._font_size == min(start_size + 1, win.FONT_MAX)
+
+    wheel_down = videobatch_gui.QtGui.QWheelEvent(
+        videobatch_gui.QtCore.QPointF(center),
+        videobatch_gui.QtCore.QPointF(center),
+        videobatch_gui.QtCore.QPoint(0, 0),
+        videobatch_gui.QtCore.QPoint(0, -120),
+        videobatch_gui.QtCore.Qt.MouseButton.NoButton,
+        videobatch_gui.QtCore.Qt.KeyboardModifier.ControlModifier,
+        videobatch_gui.QtCore.Qt.ScrollPhase.ScrollUpdate,
+        False,
+    )
+    videobatch_gui.QtWidgets.QApplication.sendEvent(win, wheel_down)
+
+    assert win._font_size == start_size
+
+
 def test_scaled_sizes_keep_total_and_positive(
     gui_runtime_available, gui_runtime_error
 ):

--- a/todo.txt
+++ b/todo.txt
@@ -1,4 +1,5 @@
 # Aufgabenliste
+- [x] Bereiche mit Strg+Mausrad skalierbar gemacht (globale Schrift-Skalierung mit Live-Feedback und GUI-Test)
 - [x] GUI-Aktionsbereich in ein strukturiertes 3x3-Grid umgebaut (Hauptaktionen) und Undo/Redo als separate Verlaufsgruppe ergänzt
 - [x] Zwei Deprecation-Warnungen in Legacy-Starttests behoben (Warnings jetzt explizit erwartet)
 - [x] Finalisierung: Vollautomatische QA-Startroutine erneut ausgefuehrt, Abhaengigkeiten auto-validiert und Endtest (288 passed) bestaetigt

--- a/videobatch_gui.py
+++ b/videobatch_gui.py
@@ -26,20 +26,30 @@ from PySide6.QtCore import Qt, Signal
 from PySide6.QtGui import QAction
 from PySide6.QtWidgets import QHeaderView
 
-from core.fallback_media import (dumps_audio_list, loads_audio_list,
-                                 persist_fallback_media)
-from core.gui_logic import (compute_workflow_min_size, normalize_layout_width,
-                            resolve_action_cell_min_width,
-                            resolve_action_layout_columns)
+from core.fallback_media import (
+    dumps_audio_list,
+    loads_audio_list,
+    persist_fallback_media,
+)
+from core.gui_logic import (
+    compute_workflow_min_size,
+    normalize_layout_width,
+    resolve_action_cell_min_width,
+    resolve_action_layout_columns,
+)
 from core.media_validation import AUDIO_EXTENSIONS, IMAGE_EXTENSIONS
-from core.output_management import (build_dated_output_dir,
-                                    transfer_with_validation)
+from core.output_management import (
+    build_dated_output_dir,
+    transfer_with_validation,
+)
 from core.paths import config_dir, log_dir, user_data_dir
 from core.plugins import PluginManager
 from core.themes import get_theme_tokens, load_themes
-from core.ui_profiles import (resolve_density_multiplier,
-                              resolve_interface_profile,
-                              resolve_spacing_profile)
+from core.ui_profiles import (
+    resolve_density_multiplier,
+    resolve_interface_profile,
+    resolve_spacing_profile,
+)
 from core.ui_texts import load_ui_texts, text_with_fallback
 from core.utils import build_out_name, probe_duration
 from core.validation import normalize_audio_bitrate, validate_output_template
@@ -47,18 +57,33 @@ from gui.dialogs.file_picker import FilePickerDialog
 from gui.main_window import build_initial_state
 from gui.services.output_preview import build_mini_preview_summary
 from gui.services.preview import play_audio_preview, stop_audio_preview
-from gui.services.project_io import (build_project_payload, load_project_file,
-                                     make_project_relative,
-                                     resolve_project_path, save_project_file)
-from gui.services.runtime_paths import (build_default_runtime_paths,
-                                        check_ffmpeg, safe_move)
-from gui.state.project_state import (get_project_root, get_project_start_dir,
-                                     set_last_project_path, set_project_root)
+from gui.services.project_io import (
+    build_project_payload,
+    load_project_file,
+    make_project_relative,
+    resolve_project_path,
+    save_project_file,
+)
+from gui.services.runtime_paths import (
+    build_default_runtime_paths,
+    check_ffmpeg,
+    safe_move,
+)
+from gui.state.project_state import (
+    get_project_root,
+    get_project_start_dir,
+    set_last_project_path,
+    set_project_root,
+)
 from gui.views.action_orchestration import choose_project_root_dialog
 from gui.views.main_window_view import create_action_buttons
 from gui.widgets.dashboard import InfoDashboard
-from gui.widgets.feedback import (ErrorBanner, InlineValidationBadge,
-                                  SuccessToast, WarningBadge)
+from gui.widgets.feedback import (
+    ErrorBanner,
+    InlineValidationBadge,
+    SuccessToast,
+    WarningBadge,
+)
 
 # ---------- Paths ----------
 APP_DIR = user_data_dir()
@@ -1074,6 +1099,8 @@ class GuidedWizard(QtWidgets.QDialog):
 # ---------- MainWindow ----------
 class MainWindow(QtWidgets.QMainWindow):
     FONT_STEP = 1
+    FONT_MIN = 10
+    FONT_MAX = 36
     WORKFLOW_SECTION_MIN_WIDTH = 180
     WORKFLOW_SECTION_MIN_HEIGHT = 190
     WORKFLOW_COLUMN_DEFAULT_WEIGHTS = (45, 55)
@@ -1126,6 +1153,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self._pending_action_reflow = False
         self._pending_table_row_resize = False
         self._pending_hint_rewrap = False
+        self._ctrl_wheel_font_zoom_enabled = True
         self._ui_recalc_timer = QtCore.QTimer(self)
         self._ui_recalc_timer.setSingleShot(True)
         self._ui_recalc_timer.timeout.connect(self._run_debounced_ui_recalc)
@@ -2089,6 +2117,9 @@ class MainWindow(QtWidgets.QMainWindow):
         self._on_focus_changed(None, self.table)
         self._sync_history_buttons()
         self._sync_sticky_export_state()
+        app = QtWidgets.QApplication.instance()
+        if app is not None:
+            app.installEventFilter(self)
 
     # ----- UI helpers -----
     def _ui_text(self, key: str, fallback: str) -> str:
@@ -2352,7 +2383,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self._set_font(value)
 
     def _set_font(self, size: int):
-        size = max(10, min(36, size))
+        size = max(self.FONT_MIN, min(self.FONT_MAX, size))
         self._font_size = size
         self._apply_font()
         if hasattr(self, "font_slider") and self.font_slider.value() != size:
@@ -2369,6 +2400,40 @@ class MainWindow(QtWidgets.QMainWindow):
     def _apply_font(self):
         f = QtGui.QFont("DejaVu Sans", self._font_size)
         self.setFont(f)
+
+    def _font_zoom_step_from_wheel(self, event: object) -> int:
+        if not isinstance(event, QtGui.QWheelEvent):
+            return 0
+        angle_delta = event.angleDelta().y()
+        if angle_delta:
+            return 1 if angle_delta > 0 else -1
+        pixel_delta = event.pixelDelta().y()
+        if pixel_delta:
+            return 1 if pixel_delta > 0 else -1
+        return 0
+
+    def eventFilter(
+        self, watched: QtCore.QObject, event: QtCore.QEvent
+    ) -> bool:
+        if (
+            self._ctrl_wheel_font_zoom_enabled
+            and event.type() == QtCore.QEvent.Type.Wheel
+            and isinstance(event, QtGui.QWheelEvent)
+            and event.modifiers() & QtCore.Qt.KeyboardModifier.ControlModifier
+            and self.isVisible()
+        ):
+            active_window = QtWidgets.QApplication.activeWindow()
+            if active_window is self or self.isAncestorOf(active_window):
+                step = self._font_zoom_step_from_wheel(event)
+                if step:
+                    self._change_font(step)
+                    self._announce_live_status(
+                        f"Skalierung angepasst: Schriftgröße {self._font_size}",
+                        timeout_ms=1800,
+                    )
+                    event.accept()
+                    return True
+        return super().eventFilter(watched, event)
 
     def _apply_theme(self, name: str):
         if name not in THEMES:
@@ -4760,6 +4825,9 @@ class MainWindow(QtWidgets.QMainWindow):
             )
 
     def closeEvent(self, event: QtGui.QCloseEvent) -> None:
+        app = QtWidgets.QApplication.instance()
+        if app is not None:
+            app.removeEventFilter(self)
         self._save_workflow_splitter_state()
         self.settings.setValue("ui/geometry", self.saveGeometry())
         self.settings.setValue("ui/window_state", self.saveState())


### PR DESCRIPTION
### Motivation
- Improve accessibility and quick UI scaling by enabling a global, keyboard-modified mouse-wheel interaction to change the app font size (useful for users who need larger text or quick temporary scaling). 
- Centralize font limits and make font changes propagate through existing adaptive layout and density logic to keep layout consistent and accessible.

### Description
- Added central font bounds `FONT_MIN` and `FONT_MAX` and switched `_set_font` to use them for consistent clamping of font sizes. 
- Implemented an app-wide `eventFilter` in `MainWindow` that listens for `Ctrl + Wheel` (`QWheelEvent`) while the window is active and adjusts font size stepwise via `_font_zoom_step_from_wheel`, with live status feedback through `_announce_live_status`. 
- Registered the event filter on window init and removed it on close to avoid side effects, and added a toggle flag `_ctrl_wheel_font_zoom_enabled` to allow disabling if needed. 
- Added a GUI test `test_ctrl_wheel_scales_font_for_main_window` in `tests/test_gui_validation.py` and updated `todo.txt` to mark the task done; applied `black` formatting to modified files.

### Testing
- Ran code formatting: `python -m black videobatch_gui.py tests/test_gui_validation.py` which reformatted the two files successfully. 
- Ran targeted GUI tests: `pytest -q tests/test_gui_validation.py -k "ctrl_wheel_scales_font_for_main_window or workflow_min_size_clamps_for_large_font_profile"` which returned `2 passed, 37 deselected`. 
- Ran UI texts tests: `pytest -q tests/test_ui_texts.py` which returned `7 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69992e0abef48325b25b3d7048c06a1d)